### PR TITLE
If no apps are migrated it should be visible but not fail

### DIFF
--- a/cmd/apply/cmd.go
+++ b/cmd/apply/cmd.go
@@ -2,6 +2,7 @@ package apply
 
 import (
 	"time"
+  "errors"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
@@ -121,9 +122,19 @@ func (c *Command) execute() error {
 
   err = mcs.ApplyCAPIApps(flags.sourceFile)
   if err != nil {
+    if errors.Is(err, cluster.MigrationFileEmpty) {
+      color.Red("⚠  Warning")
+      color.Red("⚠  No apps targeted for migration")
+      color.Red("⚠  The given file was empty")
+      color.Red("⚠  Warning")
+
+      return nil
+    }
+
     return microerror.Mask(err)
   }
-  color.Green("Apps applied successfully to %s-%s", mcs.DstMC.Name, mcs.WcName)
+
+  color.Green("Apps (%d) applied successfully to %s-%s", len(mcs.Apps), mcs.DstMC.Name, mcs.WcName)
 
   if flags.finalizer {
     mcs.SrcMC.RemoveFinalizerOnNamespace()

--- a/cmd/prepare/cmd.go
+++ b/cmd/prepare/cmd.go
@@ -125,8 +125,8 @@ func (c *Command) execute() error {
   if err != nil {
     if errors.Is(err, apps.EmptyAppsError) {
       color.Red("⚠  Warning")
-      color.Red("⚠  No apps targeted for migration.")
-      color.Red("⚠  The migration will continue but no apps.application.giantswarm.io CRs will get transferred")
+      color.Red("⚠  No apps targeted for migration")
+      color.Red("⚠  The capi-migration will continue but no apps.application.giantswarm.io CRs will get transferred")
       color.Red("⚠  Warning")
 
       return nil

--- a/cmd/prepare/cmd.go
+++ b/cmd/prepare/cmd.go
@@ -1,6 +1,8 @@
 package prepare
 
 import (
+  "errors"
+
   //	"github.com/fatih/color"
   "github.com/fatih/color"
   "github.com/spf13/cobra"
@@ -121,6 +123,15 @@ func (c *Command) execute() error {
 
   mcs.Apps, err = apps.GetAppCRs(mcs.SrcMC.KubernetesClient, mcs.WcName)
   if err != nil {
+    if errors.Is(err, apps.EmptyAppsError) {
+      color.Red("⚠  Warning")
+      color.Red("⚠  No apps targeted for migration.")
+      color.Red("⚠  The migration will continue but no apps.application.giantswarm.io CRs will get transferred")
+      color.Red("⚠  Warning")
+
+      return nil
+    }
+
     return microerror.Mask(err)
   }
 
@@ -129,7 +140,7 @@ func (c *Command) execute() error {
     return microerror.Mask(err)
   }
 
-  color.Green("Apps and config is dumped and migrated to disk: %s", mcs.AppYamlFile(flags.dumpFile))
+  color.Green("Apps (%d) and config is dumped and migrated to disk: %s", len(mcs.Apps), mcs.AppYamlFile(flags.dumpFile))
 
   return nil
 }

--- a/pkg/apps/apps.go
+++ b/pkg/apps/apps.go
@@ -21,17 +21,14 @@ func GetAppCRs(k8sClient client.Client, clusterName string) ([]app.App, error) {
     return nil, microerror.Mask(err)
   }
 
-  filteredApps := filterAppCRs(objList.Items)
+  filteredApps, err := filterAppCRs(objList.Items)
 
-  if len(filteredApps) == 0 {
-    return nil, microerror.Maskf(emptyAppsError, "No non-default apps found for migration")
-  }
-
-  return filteredApps, nil
+  return filteredApps, err
 }
 
 // blacklist certain apps for migration
-func filterAppCRs(allApps []app.App) (filteredApps []app.App) {
+func filterAppCRs(allApps []app.App) ([]app.App, error) {
+  var filteredApps []app.App
   appLoop:
   for _,application := range allApps {
     // skip "default" apps; these should be installed by default on the MC
@@ -52,5 +49,9 @@ func filterAppCRs(allApps []app.App) (filteredApps []app.App) {
     filteredApps = append(filteredApps, application)
   }
 
-  return
+  if len(filteredApps) == 0 {
+    return nil, microerror.Maskf(EmptyAppsError, "No non-default apps found for migration")
+  }
+
+  return filteredApps, nil
 }

--- a/pkg/apps/apps_test.go
+++ b/pkg/apps/apps_test.go
@@ -1,0 +1,51 @@
+package apps
+
+import (
+	"errors"
+	"testing"
+
+	app "github.com/giantswarm/apiextensions-application/api/v1alpha1"
+
+)
+
+func TestFilterAppCRsEmptyReturn(t *testing.T) {
+  emptyApp := []app.App{}
+
+  _, err := filterAppCRs(emptyApp)
+
+  if ! errors.Is(err, EmptyAppsError) {
+    t.Fatalf("Empty App List is not returning error")
+  }
+}
+
+func TestFilteringOfBundledApps(t *testing.T) {
+  appLabels := map[string]string{}
+  appLabels["giantswarm.io/managed-by"] = ""
+
+  newApp := app.App{}
+
+  newApp.Labels = appLabels
+
+  appList := []app.App{
+    newApp,
+  }
+
+  _, err := filterAppCRs(appList)
+  if ! errors.Is(err, EmptyAppsError) {
+    t.Fatalf("App Bundle should be filtered for migration")
+  }
+}
+ 
+func TestFilteringOfDefaultApps(t *testing.T) {
+  newApp := app.App{}
+  newApp.Spec.Catalog = "default"
+
+  appList := []app.App{
+    newApp,
+  }
+
+  _, err := filterAppCRs(appList)
+  if ! errors.Is(err, EmptyAppsError) {
+    t.Fatalf("Apps from the `default` catalog should be filtered")
+  }
+}

--- a/pkg/apps/error.go
+++ b/pkg/apps/error.go
@@ -4,6 +4,6 @@ import (
   "github.com/giantswarm/microerror"
 )
 
-var emptyAppsError = &microerror.Error{
+var EmptyAppsError = &microerror.Error{
   Kind: "emptyAppsError",
 }

--- a/pkg/cluster/apply.go
+++ b/pkg/cluster/apply.go
@@ -26,7 +26,7 @@ func (c *Cluster) ApplyCAPIApps(filename string) error {
   }
   // Check if the file size is 0
   if fileInfo.Size() == 0 {
-    return microerror.Maskf(migrationFileCorrupted, "Migration File is empty. Nothing to migrate") 
+    return microerror.Maskf(MigrationFileEmpty, "Migration File is empty. Nothing to migrate") 
   }
 
   // waitloop til kubeconfig/default-cluster-values are found

--- a/pkg/cluster/dump.go
+++ b/pkg/cluster/dump.go
@@ -19,9 +19,6 @@ import (
 )
 
 func (c *Cluster) DumpApps(filename string) error {
-
-  var numberOfAppsToMigrate int
-
   // we write the apps to a yaml-file, which gets applied later
   f, err := os.OpenFile(c.AppYamlFile(filename), os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0640)
 
@@ -29,25 +26,7 @@ func (c *Cluster) DumpApps(filename string) error {
     return microerror.Mask(err)
   }
 
-  appLoop:
   for _,application := range c.Apps {
-    // skip "default" apps; these should be installed by default on the MC
-    if application.Spec.Catalog == "default" {
-      continue
-    }
-
-    // skip bundled apps as we only migrate their parent
-    // todo: verify thats formally correct
-    labels := application.GetLabels()
-    for key := range labels {
-      if strings.Contains(key, "giantswarm.io/managed-by") {
-        // we skip this app completly
-        continue appLoop
-      }
-    }
-
-    numberOfAppsToMigrate += 1
-
     // 	DefaultingEnabled          bool
     // 	ExtraLabels                map[string]string
     // 	ExtraAnnotations           map[string]string

--- a/pkg/cluster/dump.go
+++ b/pkg/cluster/dump.go
@@ -18,6 +18,8 @@ import (
 
 )
 
+// todo: refactor dumping to file somewhere else
+// todo: we need to create an empty file for the later apply step
 func (c *Cluster) DumpApps(filename string) error {
   // we write the apps to a yaml-file, which gets applied later
   f, err := os.OpenFile(c.AppYamlFile(filename), os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0640)

--- a/pkg/cluster/error.go
+++ b/pkg/cluster/error.go
@@ -16,7 +16,7 @@ var clusterUnhealthy = &microerror.Error{
   Kind: "clusterUnhealthy",
 }
 
-var migrationFileCorrupted = &microerror.Error{
-  Kind: "migrationFileCorrupted",
+var MigrationFileEmpty = &microerror.Error{
+  Kind: "migrationFileEmpty",
 }
 


### PR DESCRIPTION
In some Clusters there are no non-default `apps` installed. 
In most of the Test Cases there are no non-default `apps` installed.

This changes will warn the user, but not fail the script.

### known limitations
currently the `apply` step will fail, if the input-file is not found. It will later be fixed, when we create an empty file during the `prepare` phase.  