### PR TITLE
remove finalizer default flags

### DIFF
--- a/cmd/apply/cmd.go
+++ b/cmd/apply/cmd.go
@@ -1,8 +1,8 @@
 package apply
 
 import (
+	"errors"
 	"time"
-  "errors"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
@@ -15,18 +15,18 @@ import (
 )
 
 var (
-  flags = &Flags{}
+	flags = &Flags{}
 )
 
 const (
-  // CommandUse indicates the general syntax of the command
-  CommandUse = "apply"
+	// CommandUse indicates the general syntax of the command
+	CommandUse = "apply"
 
-  // CommandShort describes the command in a short list
-  CommandShort = "Run the second stage of an app migration"
+	// CommandShort describes the command in a short list
+	CommandShort = "Run the second stage of an app migration"
 
-  // CommandLong documents the command in full length
-  CommandLong = `In the apply phase the apps and additional config will
+	// CommandLong documents the command in full length
+	CommandLong = `In the apply phase the apps and additional config will
   be read from disk and applied to the newly created capi WC
 
   Run a migration from gauss to golem:
@@ -37,111 +37,111 @@ const (
 
 // Config represents the configuration used to create a new command.
 type Config struct {
-  // Settings.
-  MainCommand *cobra.Command
-  Logger micrologger.Logger
+	// Settings.
+	MainCommand *cobra.Command
+	Logger      micrologger.Logger
 }
 
 type Command struct {
-  // Dependencies.
-  logger micrologger.Logger
+	// Dependencies.
+	logger micrologger.Logger
 
-  // Settings.
-  mainCommand *cobra.Command
+	// Settings.
+	mainCommand *cobra.Command
 }
 
 // New creates a new configured command.
 func New(config Config) (*Command, error) {
-  // Dependencies.
-  if config.Logger == nil {
-    return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
-  }
+	// Dependencies.
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
 
-  newCommand := &Command{
-    // Dependencies.
-    logger: config.Logger,
+	newCommand := &Command{
+		// Dependencies.
+		logger: config.Logger,
 
-    // Internals.
-    mainCommand: nil,
-  }
+		// Internals.
+		mainCommand: nil,
+	}
 
-  newCommand.mainCommand = &cobra.Command{
-    Use:   CommandUse,
-    Short: CommandShort,
-    Long:  CommandLong,
-    RunE:  newCommand.Execute,
-  }
+	newCommand.mainCommand = &cobra.Command{
+		Use:   CommandUse,
+		Short: CommandShort,
+		Long:  CommandLong,
+		RunE:  newCommand.Execute,
+	}
 
-  newCommand.mainCommand.Flags().StringVarP(&flags.sourceFile, "dump-file", "f", "", "Filename that contains the yaml-resources for migration")
-  newCommand.mainCommand.Flags().StringVarP(&flags.dstMC, "destination", "d", "", "Name of the destination MC")
-  newCommand.mainCommand.Flags().StringVarP(&flags.srcMC, "source", "s", "", "Name of the source MC")
-  newCommand.mainCommand.Flags().StringVarP(&flags.wcName, "wc-name", "n", "", "Name of the WC to migrate")
-  newCommand.mainCommand.Flags().StringVarP(&flags.orgNamespace, "org-namespace", "o", "", "Namespace of organization in capi, eg. org-foobar")
-  newCommand.mainCommand.Flags().BoolVarP(&flags.finalizer, "finalizer", "z", true, "Remove finalizers in the sourceMC. Setting this might result in leftover finalizers")
+	newCommand.mainCommand.Flags().StringVarP(&flags.sourceFile, "dump-file", "f", "", "Filename that contains the yaml-resources for migration")
+	newCommand.mainCommand.Flags().StringVarP(&flags.dstMC, "destination", "d", "", "Name of the destination MC")
+	newCommand.mainCommand.Flags().StringVarP(&flags.srcMC, "source", "s", "", "Name of the source MC")
+	newCommand.mainCommand.Flags().StringVarP(&flags.wcName, "wc-name", "n", "", "Name of the WC to migrate")
+	newCommand.mainCommand.Flags().StringVarP(&flags.orgNamespace, "org-namespace", "o", "", "Namespace of organization in capi, eg. org-foobar")
+	newCommand.mainCommand.Flags().BoolVarP(&flags.finalizer, "finalizer", "z", false, "Remove finalizers in the sourceMC. Setting this might result in leftover finalizers")
 
-  return newCommand, nil
+	return newCommand, nil
 }
 
 func (c *Command) CobraCommand() *cobra.Command {
-  return c.mainCommand
+	return c.mainCommand
 }
 
 func (c *Command) Execute(cmd *cobra.Command, args []string) error {
 
-  err := flags.Validate()
-  if err != nil {
-    return microerror.Mask(err)
-  }
+	err := flags.Validate()
+	if err != nil {
+		return microerror.Mask(err)
+	}
 
-  //c.logger = debug.MustWrapDebugLogger(c.logger, "error")
+	//c.logger = debug.MustWrapDebugLogger(c.logger, "error")
 
-  err = c.execute()
-  if err != nil {
-    return microerror.Mask(err)
-  }
+	err = c.execute()
+	if err != nil {
+		return microerror.Mask(err)
+	}
 
-  return nil
+	return nil
 }
 
 func (c *Command) execute() error {
 
-  mcs, err := cluster.Login(flags.srcMC, flags.dstMC)
-  if err != nil {
-    return microerror.Mask(err)
-  }
-  mcs.WcName = flags.wcName
-  mcs.SrcMC.Namespace = flags.wcName
-  mcs.OrgNamespace = flags.orgNamespace
-  mcs.BackOff = backoff.NewMaxRetries(15, 3*time.Second)
+	mcs, err := cluster.Login(flags.srcMC, flags.dstMC)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	mcs.WcName = flags.wcName
+	mcs.SrcMC.Namespace = flags.wcName
+	mcs.OrgNamespace = flags.orgNamespace
+	mcs.BackOff = backoff.NewMaxRetries(15, 3*time.Second)
 
-  //health, err := mcs.DstMC.GetWCHealth(mcs.WcName)
-  //if err != nil {
-  //  return microerror.Mask(err)
-  //}
-  //color.Green("Destination Cluster %s-%s status:", mcs.DstMC.Name, mcs.WcName, health)
+	//health, err := mcs.DstMC.GetWCHealth(mcs.WcName)
+	//if err != nil {
+	//  return microerror.Mask(err)
+	//}
+	//color.Green("Destination Cluster %s-%s status:", mcs.DstMC.Name, mcs.WcName, health)
 
-  err = mcs.ApplyCAPIApps(flags.sourceFile)
-  if err != nil {
-    if errors.Is(err, cluster.MigrationFileEmpty) {
-      color.Red("⚠  Warning")
-      color.Red("⚠  No apps targeted for migration")
-      color.Red("⚠  The given file was empty")
-      color.Red("⚠  Warning")
+	err = mcs.ApplyCAPIApps(flags.sourceFile)
+	if err != nil {
+		if errors.Is(err, cluster.MigrationFileEmpty) {
+			color.Red("⚠  Warning")
+			color.Red("⚠  No apps targeted for migration")
+			color.Red("⚠  The given file was empty")
+			color.Red("⚠  Warning")
 
-      return nil
-    }
+			return nil
+		}
 
-    return microerror.Mask(err)
-  }
+		return microerror.Mask(err)
+	}
 
-  color.Green("Apps (%d) applied successfully to %s-%s", len(mcs.Apps), mcs.DstMC.Name, mcs.WcName)
+	color.Green("Apps (%d) applied successfully to %s-%s", len(mcs.Apps), mcs.DstMC.Name, mcs.WcName)
 
-  if flags.finalizer {
-    mcs.SrcMC.RemoveFinalizerOnNamespace()
-    if err != nil {
-      return microerror.Mask(err)
-    }
-    color.Yellow("Finalizer removed on NS: %s/%s", mcs.SrcMC.Name, mcs.SrcMC.Namespace)
-  }
-  return nil
+	if flags.finalizer {
+		mcs.SrcMC.RemoveFinalizerOnNamespace()
+		if err != nil {
+			return microerror.Mask(err)
+		}
+		color.Yellow("Finalizer removed on NS: %s/%s", mcs.SrcMC.Name, mcs.SrcMC.Namespace)
+	}
+	return nil
 }

--- a/cmd/prepare/cmd.go
+++ b/cmd/prepare/cmd.go
@@ -1,33 +1,33 @@
 package prepare
 
 import (
-  "errors"
-  "os"
+	"errors"
+	"os"
 
-  //	"github.com/fatih/color"
-  "github.com/fatih/color"
-  "github.com/spf13/cobra"
+	//	"github.com/fatih/color"
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
 
-  "github.com/giantswarm/app-migration-cli/pkg/cluster"
-  "github.com/giantswarm/app-migration-cli/pkg/apps"
+	"github.com/giantswarm/app-migration-cli/pkg/apps"
+	"github.com/giantswarm/app-migration-cli/pkg/cluster"
 
-  "github.com/giantswarm/microerror"
-  "github.com/giantswarm/micrologger"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
 )
 
 var (
-  flags = &Flags{}
+	flags = &Flags{}
 )
 
 const (
-  // CommandUse indicates the general syntax of the command
-  CommandUse = "prepare"
+	// CommandUse indicates the general syntax of the command
+	CommandUse = "prepare"
 
-  // CommandShort describes the command in a short list
-  CommandShort = "Run the first stage of an app migration"
+	// CommandShort describes the command in a short list
+	CommandShort = "Run the first stage of an app migration"
 
-  // CommandLong documents the command in full length
-  CommandLong = `In the preparation phase the apps and additional config will
+	// CommandLong documents the command in full length
+	CommandLong = `In the preparation phase the apps and additional config will
   be written to disk and finalizers will protect the
   namespace from deletion by the capi-migration (enabled by default)
 
@@ -39,123 +39,123 @@ const (
 
 // Config represents the configuration used to create a new command.
 type Config struct {
-  // Settings.
-  MainCommand *cobra.Command
-  Logger micrologger.Logger
+	// Settings.
+	MainCommand *cobra.Command
+	Logger      micrologger.Logger
 }
 
 type Command struct {
-  // Dependencies.
-  logger micrologger.Logger
+	// Dependencies.
+	logger micrologger.Logger
 
-  // Settings.
-  mainCommand *cobra.Command
+	// Settings.
+	mainCommand *cobra.Command
 }
 
 // New creates a new configured command.
 func New(config Config) (*Command, error) {
-  // Dependencies.
-  if config.Logger == nil {
-    return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
-  }
+	// Dependencies.
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
 
-  newCommand := &Command{
-    // Dependencies.
-    logger: config.Logger,
+	newCommand := &Command{
+		// Dependencies.
+		logger: config.Logger,
 
-    // Internals.
-    mainCommand: nil,
-  }
+		// Internals.
+		mainCommand: nil,
+	}
 
-  newCommand.mainCommand = &cobra.Command{
-    Use:   CommandUse,
-    Short: CommandShort,
-    Long:  CommandLong,
-    RunE:  newCommand.Execute,
-  }
+	newCommand.mainCommand = &cobra.Command{
+		Use:   CommandUse,
+		Short: CommandShort,
+		Long:  CommandLong,
+		RunE:  newCommand.Execute,
+	}
 
-  newCommand.mainCommand.Flags().StringVarP(&flags.srcMC, "source", "s", "", "Name of the source MC")
-  newCommand.mainCommand.Flags().StringVarP(&flags.dstMC, "destination", "d", "", "Name of the destination MC")
-  newCommand.mainCommand.Flags().StringVarP(&flags.wcName, "wc-name", "n", "", "Name of the WC to migrate")
-  newCommand.mainCommand.Flags().StringVarP(&flags.orgNamespace, "org-namespace", "o", "", "Namespace of organization in capi, eg. org-foobar")
-  newCommand.mainCommand.Flags().StringVarP(&flags.dumpFile, "output-file", "f", "", "Name of the file where the app/cm dump will be stored")
-  newCommand.mainCommand.Flags().BoolVarP(&flags.finalizer, "finalizer", "z", true, "Apply finalizers to the source namespace. Setting this might result in the deletion of the ns during the infrastructre migration")
+	newCommand.mainCommand.Flags().StringVarP(&flags.srcMC, "source", "s", "", "Name of the source MC")
+	newCommand.mainCommand.Flags().StringVarP(&flags.dstMC, "destination", "d", "", "Name of the destination MC")
+	newCommand.mainCommand.Flags().StringVarP(&flags.wcName, "wc-name", "n", "", "Name of the WC to migrate")
+	newCommand.mainCommand.Flags().StringVarP(&flags.orgNamespace, "org-namespace", "o", "", "Namespace of organization in capi, eg. org-foobar")
+	newCommand.mainCommand.Flags().StringVarP(&flags.dumpFile, "output-file", "f", "", "Name of the file where the app/cm dump will be stored")
+	newCommand.mainCommand.Flags().BoolVarP(&flags.finalizer, "finalizer", "z", false, "Apply finalizers to the source namespace. Setting this might result in the deletion of the ns during the infrastructre migration")
 
-  return newCommand, nil
+	return newCommand, nil
 }
 
 func (c *Command) CobraCommand() *cobra.Command {
-  return c.mainCommand
+	return c.mainCommand
 }
 
 func (c *Command) Execute(cmd *cobra.Command, args []string) error {
 
-  err := flags.Validate()
-  if err != nil {
-    return microerror.Mask(err)
-  }
+	err := flags.Validate()
+	if err != nil {
+		return microerror.Mask(err)
+	}
 
-  //c.logger = debug.MustWrapDebugLogger(c.logger, "error")
+	//c.logger = debug.MustWrapDebugLogger(c.logger, "error")
 
-  err = c.execute()
-  if err != nil {
-    return microerror.Mask(err)
-  }
+	err = c.execute()
+	if err != nil {
+		return microerror.Mask(err)
+	}
 
-  return nil
+	return nil
 }
 
 func (c *Command) execute() error {
-  mcs, err := cluster.Login(flags.srcMC, flags.dstMC)
-  if err != nil {
-    return microerror.Mask(err)
-  }
-  mcs.WcName = flags.wcName
-  mcs.SrcMC.Namespace = flags.wcName
-  mcs.OrgNamespace = flags.orgNamespace
+	mcs, err := cluster.Login(flags.srcMC, flags.dstMC)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	mcs.WcName = flags.wcName
+	mcs.SrcMC.Namespace = flags.wcName
+	mcs.OrgNamespace = flags.orgNamespace
 
-  f, err := os.OpenFile(mcs.AppYamlFile(flags.dumpFile), os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0640)
-  if err != nil {
-    return microerror.Mask(err)
-  }
-  defer f.Close()
+	f, err := os.OpenFile(mcs.AppYamlFile(flags.dumpFile), os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0640)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	defer f.Close()
 
-  if flags.finalizer {
-    err = mcs.SrcMC.SetFinalizerOnNamespace()
-    if err != nil {
-      return microerror.Mask(err)
-    }
-    color.Yellow("Finalizer set on NS: %s-%s", mcs.SrcMC.Name, mcs.SrcMC.Namespace)
-  }
+	if flags.finalizer {
+		err = mcs.SrcMC.SetFinalizerOnNamespace()
+		if err != nil {
+			return microerror.Mask(err)
+		}
+		color.Yellow("Finalizer set on NS: %s-%s", mcs.SrcMC.Name, mcs.SrcMC.Namespace)
+	}
 
-  mcs.Apps, err = apps.GetAppCRs(mcs.SrcMC.KubernetesClient, mcs.WcName)
-  if err != nil {
-    if errors.Is(err, apps.EmptyAppsError) {
-      color.Red("⚠  Warning")
-      color.Red("⚠  No apps targeted for migration")
-      color.Red("⚠  The capi-migration will continue but no apps.application.giantswarm.io CRs will be transferred")
-      color.Red("⚠  Warning")
+	mcs.Apps, err = apps.GetAppCRs(mcs.SrcMC.KubernetesClient, mcs.WcName)
+	if err != nil {
+		if errors.Is(err, apps.EmptyAppsError) {
+			color.Red("⚠  Warning")
+			color.Red("⚠  No apps targeted for migration")
+			color.Red("⚠  The capi-migration will continue but no apps.application.giantswarm.io CRs will be transferred")
+			color.Red("⚠  Warning")
 
-      if err := f.Close(); err != nil {
-        return microerror.Mask(err)
-      }
+			if err := f.Close(); err != nil {
+				return microerror.Mask(err)
+			}
 
-      return nil
-    }
+			return nil
+		}
 
-    return microerror.Mask(err)
-  }
+		return microerror.Mask(err)
+	}
 
-  err = mcs.DumpApps(f)
-  if err != nil {
-    return microerror.Mask(err)
-  }
+	err = mcs.DumpApps(f)
+	if err != nil {
+		return microerror.Mask(err)
+	}
 
-  color.Green("Apps (%d) and config is dumped and migrated to disk: %s", len(mcs.Apps), mcs.AppYamlFile(flags.dumpFile))
+	color.Green("Apps (%d) and config is dumped and migrated to disk: %s", len(mcs.Apps), mcs.AppYamlFile(flags.dumpFile))
 
-  if err := f.Close(); err != nil {
-    return microerror.Mask(err)
-  }
+	if err := f.Close(); err != nil {
+		return microerror.Mask(err)
+	}
 
-  return nil
+	return nil
 }


### PR DESCRIPTION
until now finalizers were applied to the source NS to prevent its deletion during the migration process. For some reason the cleanup didn't succeed. By default no finalizers will be applied nor removed.