### PR TITLE
skip-migration-of-k8s-initiator-app

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/giantswarm/micrologger v1.1.1
 	github.com/spf13/cobra v1.8.0
 	golang.org/x/net v0.20.0
-	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.29.0
 	k8s.io/apimachinery v0.29.0
 	k8s.io/client-go v0.29.0
@@ -77,6 +76,7 @@ require (
 	google.golang.org/protobuf v1.31.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.28.4 // indirect
 	k8s.io/component-base v0.28.4 // indirect
 	k8s.io/klog/v2 v2.110.1 // indirect

--- a/pkg/apps/apps.go
+++ b/pkg/apps/apps.go
@@ -1,57 +1,62 @@
 package apps
 
 import (
-  "context"
-  "strings"
+	"context"
+	"strings"
 
-  "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
-  app "github.com/giantswarm/apiextensions-application/api/v1alpha1"
-  "github.com/giantswarm/microerror"
+	app "github.com/giantswarm/apiextensions-application/api/v1alpha1"
+	"github.com/giantswarm/microerror"
 )
 
 func GetAppCRs(k8sClient client.Client, clusterName string) ([]app.App, error) {
-  objList := &app.AppList{}
+	objList := &app.AppList{}
 
-  // todo: not possible to filter on "spec.catalog" bc/ cached list not indexed?
-  selector := client.MatchingFields{"metadata.namespace": clusterName}
-  //selector := client.MatchingLabels{"app.kubernetes.io/name"
-  err := k8sClient.List(context.TODO(), objList, selector)
-  if err != nil {
-    return nil, microerror.Mask(err)
-  }
+	// todo: not possible to filter on "spec.catalog" bc/ cached list not indexed?
+	selector := client.MatchingFields{"metadata.namespace": clusterName}
+	//selector := client.MatchingLabels{"app.kubernetes.io/name"
+	err := k8sClient.List(context.TODO(), objList, selector)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
 
-  filteredApps, err := filterAppCRs(objList.Items)
+	filteredApps, err := filterAppCRs(objList.Items)
 
-  return filteredApps, err
+	return filteredApps, err
 }
 
 // blacklist certain apps for migration
 func filterAppCRs(allApps []app.App) ([]app.App, error) {
-  var filteredApps []app.App
-  appLoop:
-  for _,application := range allApps {
-    // skip "default" apps; these should be installed by default on the MC
-    if application.Spec.Catalog == "default" {
-      continue
-    }
+	var filteredApps []app.App
+appLoop:
+	for _, application := range allApps {
+		// skip "default" apps; these should be installed by default on the MC
+		if application.Spec.Catalog == "default" {
+			continue
+		}
 
-    // skip bundled apps as we only migrate their parent
-    // todo: verify thats formally correct
-    labels := application.GetLabels()
-    for key := range labels {
-      if strings.Contains(key, "giantswarm.io/managed-by") {
-        // we skip this app completly
-        continue appLoop
-      }
-    }
+		// skip bundled apps as we only migrate their parent
+		// todo: verify thats formally correct
+		labels := application.GetLabels()
+		for key := range labels {
+			if strings.Contains(key, "giantswarm.io/managed-by") {
+				// we skip this app completly
+				continue appLoop
+			}
+		}
 
-    filteredApps = append(filteredApps, application)
-  }
+		// skip specific apps that are no longer supported on CAPI
+		if application.Spec.Name == "k8s-initiator-app" {
+			continue
+		}
 
-  if len(filteredApps) == 0 {
-    return nil, microerror.Maskf(EmptyAppsError, "No non-default apps found for migration")
-  }
+		filteredApps = append(filteredApps, application)
+	}
 
-  return filteredApps, nil
+	if len(filteredApps) == 0 {
+		return nil, microerror.Maskf(EmptyAppsError, "No non-default apps found for migration")
+	}
+
+	return filteredApps, nil
 }


### PR DESCRIPTION
Ignore `k8s-initiator-app` during the migration


 looks like the file was not properly formated with `go fmt`  so that's why there are so many changes