### PR TITLE
Do not migrate `<WC>-cluster-values` config map or secret from vintage to CAPI MC since then cluster-app-operator cannot create those objects with the new values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Do not migrate `<WC>-cluster-values` config map or secret from vintage to CAPI MC since then cluster-app-operator cannot create those objects with the new values
+
 ## [0.2.0] - 2024-08-07
 
 ### Changed


### PR DESCRIPTION
See [problem details in chat](https://gigantic.slack.com/archives/C02HLSDH3DZ/p1727266463435419). Here's the gist:

My test cluster was migrated, but then I still saw the vintage base domain on the CAPI MC:

```
$ kubectl get cm -n org-capa-migration-testing andreas187-cluster-values -o yaml | grep ' baseDomain' # ran this on MC grizzly
    baseDomain: andreas187.k8s.garfish.eu-central-1.aws.gigantic.io
```

With that config map already existing, cluster-apps-operator wouldn't be able to create/reconcile the object (did I ever mention that I hate reconcilers that don't reconcile??):

```
"message":"already created ConfigMap `andreas187-cluster-values` in namespace `org-capa-migration-testing`","object":"org-capa-migration-testing/andreas187","resource":"clusterconfigmap","time":"2024-09-25T13:49:38.727089+00:00"
```

We must not migrate the `<WC>-cluster-values` config map or secret to the CAPI MC, since it's generated by cluster-apps-operator. There's no risk with this, I think, given that `app-migration-cli apply` waits until cluster-apps-operator has created those critical objects.