### PR TITLE
Filter out app `k8s-initiator-app-cgroupsv1`

### DIFF
--- a/pkg/apps/apps.go
+++ b/pkg/apps/apps.go
@@ -2,6 +2,7 @@ package apps
 
 import (
 	"context"
+	"slices"
 	"strings"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -47,7 +48,10 @@ appLoop:
 		}
 
 		// skip specific apps that are no longer supported on CAPI
-		if application.Spec.Name == "k8s-initiator-app" {
+		if slices.Contains([]string{
+			"k8s-initiator-app",
+			"k8s-initiator-app-cgroupsv1",
+		}, application.Spec.Name) {
 			continue
 		}
 

--- a/pkg/apps/apps_test.go
+++ b/pkg/apps/apps_test.go
@@ -105,15 +105,20 @@ func TestFilteringOfDefaultApps(t *testing.T) {
 }
 
 func TestFilteringOfNamedApps(t *testing.T) {
-	newApp := app.App{}
-	newApp.Spec.Name = "k8s-initiator-app"
+	for _, appNameToFilter := range []string{
+		"k8s-initiator-app",
+		"k8s-initiator-app-cgroupsv1",
+	} {
+		newApp := app.App{}
+		newApp.Spec.Name = appNameToFilter
 
-	appList := []app.App{
-		newApp,
-	}
+		appList := []app.App{
+			newApp,
+		}
 
-	_, err := filterAppCRs(appList)
-	if !errors.Is(err, EmptyAppsError) {
-		t.Fatalf("Apps named `%s` catalog should be filtered", newApp.Spec.Name)
+		_, err := filterAppCRs(appList)
+		if !errors.Is(err, EmptyAppsError) {
+			t.Fatalf("Apps named `%s` catalog should be filtered", newApp.Spec.Name)
+		}
 	}
 }


### PR DESCRIPTION
We found this app on a customer cluster. Its chart failed to pull, probably because there's no such repository in Giant Swarm's GitHub, or because the project really never existed. Anyway, ditch that app during migration.